### PR TITLE
remove non-relevant section

### DIFF
--- a/modules/ROOT/pages/_partials/generic-provisioning-end.adoc
+++ b/modules/ROOT/pages/_partials/generic-provisioning-end.adoc
@@ -1,13 +1,5 @@
 
-After the service has been provisioned, you should then be able to see the service's secret and config map created during provision
-within the project's resources.
-
-To edit the service configuration:
-
-. Log into the OpenShift Console
-. Navigate to *Resources* -> *Config Maps* and select the service's config map.
-. Press the *[Actions]* button in the upper right corner and choose *[Edit]* or *[Edit YAML]*. This
-allows you to edit the service's configuration directly which is then exposed to your mobile app.
+After the service has been provisioned, you should then be able to see it in the project overview.
 
 == Deprovisioning
 In order to delete a provisioned service, select the service menu and click *Delete*. A notification 

--- a/modules/ROOT/pages/push/provisioning.adoc
+++ b/modules/ROOT/pages/push/provisioning.adoc
@@ -11,5 +11,4 @@ include::{partialsdir}/attributes.adoc[]
 
 include::{partialsdir}/generic-provisioning.adoc[]
 
-
- include::{partialsdir}/generic-provisioning-end.adoc[]
+include::{partialsdir}/generic-provisioning-end.adoc[]


### PR DESCRIPTION
Remove the section about editing the config maps from the docs. The user should not have to do this, our APBs have to set this up correctly.

Also removed the single space in front of an include. Otherwise it doesn't work.