### PR TITLE
Handling a Message, with code examples from showcase apps

### DIFF
--- a/modules/ROOT/pages/push/handling-push-notifications.adoc
+++ b/modules/ROOT/pages/push/handling-push-notifications.adoc
@@ -50,6 +50,5 @@ The {SDK} for iOS does not provide a way to handle incoming messages. Instead, f
 ****
 
 The {SDK} for JavaScript does not provide a way to handle incoming messages. We recommend using the link:https://ionicframework.com/docs/native/push[Ionic Push plugin].
-[source,javascript]
 
 ****

--- a/modules/ROOT/pages/push/handling-push-notifications.adoc
+++ b/modules/ROOT/pages/push/handling-push-notifications.adoc
@@ -1,3 +1,54 @@
 include::{partialsdir}/attributes.adoc[]
 
 = Handling Push Notifications
+
+Follow the next steps to handle incoming {push-notification}s in your foregrounded application.
+
+NOTE: {push-notification}s that arrive when the application is in the background will always be handled by the OS.
+
+[role="primary"]
+.Android
+****
+Add your implementation of *MessageHandler* to your application's manifest.
+
+[source,xml]
+----
+<meta-data
+    android:name="DEFAULT_MESSAGE_HANDLER_KEY"
+    android:value=".MyMessageHandler" />
+----
+****
+
+
+[role="secondary"]
+.iOS
+****
+[source,swift]
+----
+TODO
+----
+****
+
+
+[role="secondary"]
+.Cordova
+****
+[source,javascript]
+----
+import { Push } from "@ionic-native/push";
+
+const pushObject = new Push().init({
+    android: {},
+    ios: {
+      alert: true,
+      badge: true,
+      sound: true
+    }
+});
+
+pushObject.on("notification")
+  .subscribe(notification => {
+    // Handle notification...
+  });
+----
+****

--- a/modules/ROOT/pages/push/handling-push-notifications.adoc
+++ b/modules/ROOT/pages/push/handling-push-notifications.adoc
@@ -23,9 +23,17 @@ Add your implementation of *MessageHandler* to your application's manifest.
 [role="secondary"]
 .iOS
 ****
+Add an observer to NotificationCenter from AGSPush:
 [source,swift]
 ----
-TODO
+override func viewDidLoad() {
+    super.viewDidLoad()
+    NotificationCenter.default.addObserver(self, selector: #selector(MyPushView.messageReceived(_:)), name: Notification.Name(rawValue: "message_received"), object: nil)
+}
+
+@objc func messageReceived(_ notification: Notification) {
+    // Handle notification...
+}
 ----
 ****
 

--- a/modules/ROOT/pages/push/handling-push-notifications.adoc
+++ b/modules/ROOT/pages/push/handling-push-notifications.adoc
@@ -14,7 +14,7 @@ Add to your project an implementation of *MessageHandler*:
 
 [source,java]
 ----
-public class NotificationBarMessageHandler implements MessageHandler {
+public class MyMessageHandler implements MessageHandler {
 
     @Override
     public void onMessage(Context context, Map<String, String> message) {

--- a/modules/ROOT/pages/push/handling-push-notifications.adoc
+++ b/modules/ROOT/pages/push/handling-push-notifications.adoc
@@ -9,7 +9,22 @@ NOTE: {push-notification}s that arrive when the application is in the background
 [role="primary"]
 .Android
 ****
-Add your implementation of *MessageHandler* to your application's manifest.
+
+Add to your project an implementation of *MessageHandler*:
+
+[source,java]
+----
+public class NotificationBarMessageHandler implements MessageHandler {
+
+    @Override
+    public void onMessage(Context context, Map<String, String> message) {
+        // Handle incoming message
+    }
+
+}
+----
+
+Add it to your application's manifest.
 
 [source,xml]
 ----
@@ -17,46 +32,24 @@ Add your implementation of *MessageHandler* to your application's manifest.
     android:name="DEFAULT_MESSAGE_HANDLER_KEY"
     android:value=".MyMessageHandler" />
 ----
+
 ****
 
 
 [role="secondary"]
 .iOS
 ****
-Add an observer to NotificationCenter from AGSPush:
-[source,swift]
-----
-override func viewDidLoad() {
-    super.viewDidLoad()
-    NotificationCenter.default.addObserver(self, selector: #selector(MyPushView.messageReceived(_:)), name: Notification.Name(rawValue: "message_received"), object: nil)
-}
 
-@objc func messageReceived(_ notification: Notification) {
-    // Handle notification...
-}
-----
+The {SDK} for iOS does not provide a way to handle incoming messages. Instead, follow the link:https://developer.apple.com/notifications/[Apple's official documentation] about notifications.
+
 ****
 
 
 [role="secondary"]
 .Cordova
 ****
+
+The {SDK} for JavaScript does not provide a way to handle incoming messages. We recommend using the link:https://ionicframework.com/docs/native/push[Ionic Push plugin].
 [source,javascript]
-----
-import { Push } from "@ionic-native/push";
 
-const pushObject = new Push().init({
-    android: {},
-    ios: {
-      alert: true,
-      badge: true,
-      sound: true
-    }
-});
-
-pushObject.on("notification")
-  .subscribe(notification => {
-    // Handle notification...
-  });
-----
 ****


### PR DESCRIPTION
Motivation: https://issues.jboss.org/browse/AEROGEAR-3007

There are many problems with tagging the code in showcase examples.

- In Android, the code is in a XML file so the comments have a different format than `//`.
- In Cordova, the implementation is very attached to the framework and architecture of the showcase app (ionic) and it's not possible to keep the snippet brief and clear (see [code](https://github.com/aerogear/cordova-showcase-template/blob/master/src/services/push.service.ts)).