### PR TITLE
add local development setup docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -68,6 +68,8 @@ include::{partialsdir}/attributes.adoc[]
 ** xref:testcard.adoc[{custom-service} for the Showcase App]
 ** xref:testcard.adoc[{unifiedpush-service} for the Showcase App]
 
+* xref:local_development.adoc[Setting up {org-name} {product-name} locally]
+
 .Reference
 * xref:ref_api.adoc[API Reference]
 * xref:mobile-cli.adoc[Mobile CLI]

--- a/modules/ROOT/pages/_partials/attributes.adoc
+++ b/modules/ROOT/pages/_partials/attributes.adoc
@@ -2,7 +2,9 @@
 
 :product-name: Mobile Services
 
-:service-name:
+:release-number: 1.0.0-alpha
+
+:service-name:  
 
 :mobile-client: mobile app record
 :mobile-cli: Mobile CLI

--- a/modules/ROOT/pages/getting-started-with-openshift.adoc
+++ b/modules/ROOT/pages/getting-started-with-openshift.adoc
@@ -10,6 +10,8 @@ A project is automatically created for you, and typically you use that project t
 
 When you start OpenShift for the first time, the mobile addon may require some time to complete and mobile services might not appear in the service catalog for a few minutes. 
 
+See the guide on how to xref:local_development.adoc[Set up a local installation of {org-name} {product-name}] 
+
 == Related Information
 
 * xref:workflow.adoc[Overview of Using Mobile Services]

--- a/modules/ROOT/pages/local_development.adoc
+++ b/modules/ROOT/pages/local_development.adoc
@@ -1,0 +1,147 @@
+include::{partialsdir}/attributes.adoc[]
+
+= Local Development
+
+To facilitate the development of mobile services on a users 
+local machine or trialling {org-name} {product-name} without requiring 
+extra hardware, it is possible to bring up {org-name} {product-name} on 
+your local machine. This guide takes you through the process 
+of setting up {org-name} {product-name} locally.
+
+== Requirements
+
+=== Ansible
+
+Ansible version 2.3 or later is a requirement of running the 
+installation scripts on your local machine, follow the 
+installation steps
+link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html[here].
+
+=== Node.js
+
+Node.js version 8 or later and the bundled package manager 'npm' 
+are a requirement for certain scripts in the installation process, 
+install these with the instructions:
+link:https://nodejs.org/en/download/package-manager/[here].
+
+=== OpenShift Client Tools
+
+The OpenShift client tools are a requirement and must be 3.9 or greater,
+they can be downloaded from 
+link:https://www.openshift.org/download.html[here].
+
+=== Mobile-core Installer
+
+We configure the local development installation of {org-name} {product-name}
+using ansible scripts in our link:https://github.com/aerogear/mobile-core[mobile-core] repo.
+
+Clone this repo to your local machine and check out the {release-number} tag using:
+```
+git clone git@github.com:aerogear/mobile-core.git
+git checkout {release-number}
+```
+
+=== Docker
+
+Docker is a requirement, and must be version 17.09.1 in order to be compatible with 
+the latest release of OpenShift, depending on your OS this is downloaded from different places:
+
+==== Darwin / MacOSX
+
+On Darwin / MacOSX operating systems, you must install version 
+link:https://download.docker.com/mac/stable/19543/Docker.dmg[17.09.1] of Docker.
+
+==== Linux
+
+On Linux you must install version 17.09.1 of Docker which is available 
+link:https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.1.ce-1.el7.centos.x86_64.rpm[here].
+
+=== Installation
+
+The installation process is straightforward when using the `install.sh` 
+script - which is available in the mobile-core repo we have already
+cloned in the requirements section - with the following command:
+```
+./installer/install.sh
+```
+
+This validates that ansible, npm, docker and the OpenShift Client Tools
+are installed and are the right version.
+
+Once verified it prompts you for your docker hub login credentials, which
+must be valid for the installation to continue.
+
+The next set of values are optional and can be left with the default values:
+```
+DockerHub Tag (Defaults to {release-number}): 
+DockerHub Organisation (Defaults to aerogearcatalog): 
+Cluster IP (Defaults to 192.168.37.1): 
+Wildcard DNS Host (Defaults to nip.io): 
+```
+
+The first two values here are used to configure the service-catalog in the 
+resulting cluster to look at other docker registries or tags to fetch the 
+APBs from, but unless you are already familiar with editing these values, 
+the defaults are the safest option.
+
+The following 2 options alter what IP address and wildcard DNS host you wish
+to use.
+
+==== Cluster IP
+In order to allow communication between your mobile device and the cluster, the 
+cluster IP must be in the same c-block as your local network.
+
+i.e. If your local router which both your workstation and mobile are connected to 
+a router using the 10.0.0.x c-block, then you should set the cluster IP to something
+in the 10.0.0.x c-block too, such as 10.0.0.135.
+
+=== Finishing the installation
+
+The following installation can take a while the first time it runs as it pulls 
+quite a few docker images.
+
+Once completed succesfully, this will end with output similar to:
+```
+TASK [output-oc-cluster-status : debug] ******************************************************************************************************************************************************
+ok: [localhost] => {
+    "msg": [
+        "Web console URL: https://192.168.37.1:8443/console/", 
+        "", 
+        "Config is at host directory /var/lib/origin/openshift.local.config", 
+        "Volumes are at host directory /var/lib/origin/openshift.local.volumes", 
+        "Persistent volumes are at host directory /var/lib/origin/openshift.local.pv", 
+        "Data is at host directory /path/to/mobile-core/ui/openshift-data"
+    ]
+}
+
+PLAY RECAP ***********************************************************************************************************************************************************************************
+localhost                  : ok=44   changed=17   unreachable=0    failed=0   
+```
+
+Which signifies that your installation has completed succesfully.
+
+=== Verification
+
+To verify that your installation has completed succesfully, you can open your
+favourite browser and (accepting the self-signed certificate) you can browse 
+to:
+```
+https://192.168.37.1:8443/console/
+```
+
+The developer login credentials are:
+```
+username: developer
+password: password
+```
+
+The admin login credentials are:
+```
+username: admin
+password: admin
+```
+
+Once logged in look for the "mobile" category across the top of the catalog package
+which indicates that the mobile features of {org-name} {product-name} have been succesfully
+installed and enabled in your local cluster and that you are ready to start your local
+development.


### PR DESCRIPTION
add local development setup docs.

I have been struggling to verify this locally using:

```
 ./bin/build.sh local-site.yml
```
or
```
 ./bin/quick-build.sh local-site.yml
```

These scripts are complaining about formatting in unrelated files and will not serve a local copy of the site - even if I fix the issues it does not like - if there are suggestions to get this working, please let me know.