### PR TITLE
remove binding page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -50,7 +50,6 @@ include::{partialsdir}/attributes.adoc[]
 // DIGGER
 ** xref:digger/index.adoc[{digger-service}]
 *** xref:digger/provisioning.adoc[Provisioning]
-*** xref:digger/binding.adoc[Binding]
 *** xref:digger/configuring-dev-env-digger.adoc[Configuring a Dev environment]
 // CUSTOM
 ** xref:custom/index.adoc[{custom-service}]

--- a/modules/ROOT/pages/digger/binding.adoc
+++ b/modules/ROOT/pages/digger/binding.adoc
@@ -1,7 +1,0 @@
-include::{partialsdir}/attributes.adoc[]
-
-:service-name: Digger
-
-= Binding a {mobile-client} with the {service-name} Service
-
-include::{partialsdir}/generic-binding.adoc[]


### PR DESCRIPTION
mobile CI/CD cannot be bound to mobile services. Remove this section.