### PR TITLE
removed unneeded section

### DIFF
--- a/modules/ROOT/pages/_partials/registering-a-mobile-app.adoc
+++ b/modules/ROOT/pages/_partials/registering-a-mobile-app.adoc
@@ -20,8 +20,3 @@ You can filter the catalog items to only show mobile specific items by clicking 
 . Click the *Apps* tab and then choose the mobile platform (Android, iOS, Cordova or Xamarin) and follow the wizard.
 
 After the {mobile-client} is provisioned, you can navigate to it from Project Overview. This screen displays a list of mobile services that you can associate with the {mobile-client} and offers to provision any mobile service that is in the service catalog but is not currently provisioned. 
-
-[discrete]
-== Related Information
-
-After registering a {mobile-client}, you must bind it to a mobile service and use the AeroGear SDK to avail of the mobile service features. 


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/AEROGEAR-3514

**What**
Remove unneeded section

This section is only included in one place in the getting started page but is linked to from a number of getting started guides in the Mobile CI|CD section. These are links from prerequisites though so I believe this section is also not needed in this context.

**Example of the link:**
https://finp.github.io/aerogear/latest/registering-a-mobile-app.html which is linked from the Mobile CI|CD section https://finp.github.io/aerogear/latest/mobile-cicd.html#proc_deploying-a-mobile-app_proc_deploying-a-mobile-app

@finp 