### PR TITLE
remove delete steps from end of provision

### DIFF
--- a/modules/ROOT/pages/_partials/generic-provisioning-end.adoc
+++ b/modules/ROOT/pages/_partials/generic-provisioning-end.adoc
@@ -1,6 +1,2 @@
 
-After the service is provisioned, you can see it in the project overview.
-
-== Additional Information
-In order to delete a provisioned service, select the service menu and click *Delete*. A notification 
-appears that the service has now been *Marked for Deletion*.
+Once the wizard steps are completed navigate to the Project Overview in OpenShift to see the newly provisioned service.


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/AEROGEAR-3522

**What**
Updated the text that is shown at the end of the provision service steps

**Why**
This file is called by the majority of the provision service files. The task was to remove it from the getting started guide but it doesn't make sense to include steps on deleting the service right after provisioning it. We can optionally add a new Section to the Services tab titled "Deleting a Service" @finp @johnfriz wdyt?