### PR TITLE
AEROGEAR - 3508 - add docker version to oc cluster up doc links

### DIFF
--- a/modules/ROOT/pages/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/installing-mobile-services.adoc
@@ -17,11 +17,7 @@ NOTE: {org-name} recommends running OpenShift using the method described here. H
 WARNING: OpenShift oc executable must be located in a system location that is known to all shells (e.g. /usr/local/bin)
 
 +
-NOTE: Ensure link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started[oc cluster up] is working.
-
-* link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html[Ansible] (tested with version 2.4, but should work with version 2.3 or later)
-
-* Docker must be version 17.09.1 in order to be compatible with the latest release of OpenShift and depending on your OS this is downloaded from different places:
+NOTE: Ensure link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started[oc cluster up] is working. Docker must be version 17.09.1 in order to be compatible with the latest release of OpenShift and depending on your OS this is downloaded from different places:
 
 [role="primary"]
 .MacOS
@@ -38,6 +34,8 @@ You can download Docker CE version 17.09.1 for rpm based distros from link:https
 ****
 
 * A link:https://hub.docker.com/[Docker Hub] account
+
+* link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html[Ansible] (tested with version 2.4, but should work with version 2.3 or later)
 
 [[firewall-requirements]]
 === Firewall Requirements (Required)

--- a/modules/ROOT/pages/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/installing-mobile-services.adoc
@@ -17,7 +17,10 @@ NOTE: {org-name} recommends running OpenShift using the method described here. H
 WARNING: OpenShift oc executable must be located in a system location that is known to all shells (e.g. /usr/local/bin)
 
 +
-NOTE: Ensure link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started[oc cluster up] is working. Docker must be version 17.09.1 in order to be compatible with the latest release of OpenShift and depending on your OS this is downloaded from different places:
+NOTE: Ensure that you can run oc cluster up services.link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started[oc cluster up] with no errors before moving on to the installation of AeroGear.
+
++
+NOTE: Docker must be version 17.09.1 in order to be compatible with the latest release of OpenShift and AeroGear Mobile Services. This version may be different from the version listed on the oc cluster up documentation. You must ensure you are running with this version of docker and that oc cluster works without errors before moving on. Depending on your OS this is downloaded from different places:
 
 [role="primary"]
 .MacOS

--- a/modules/ROOT/pages/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/installing-mobile-services.adoc
@@ -17,7 +17,7 @@ NOTE: {org-name} recommends running OpenShift using the method described here. H
 WARNING: OpenShift oc executable must be located in a system location that is known to all shells (e.g. /usr/local/bin)
 
 +
-NOTE: Ensure that you can run oc cluster up services.link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started[oc cluster up] with no errors before moving on to the installation of AeroGear.
+NOTE: Ensure that you can run link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started[oc cluster up] with no errors before moving on to the installation of AeroGear.
 
 +
 NOTE: Docker must be version 17.09.1 in order to be compatible with the latest release of OpenShift and AeroGear Mobile Services. This version may be different from the version listed on the oc cluster up documentation. You must ensure you are running with this version of docker and that oc cluster works without errors before moving on. Depending on your OS this is downloaded from different places:


### PR DESCRIPTION
## JIRA 
https://issues.jboss.org/browse/AEROGEAR-3508
## Screenshot
![update-prereq](https://user-images.githubusercontent.com/14313111/42166254-4a9d9608-7e02-11e8-8324-f9c37819e69f.png)
## Additional Info
On the assumption of changes from https://github.com/aerogear/mobile-docs/pull/130 getting merged, I changed around the format to add the docker version to the oc cluster up note. Just looking for feedback on this.