### PR TITLE
AEROGEAR-3523 - added screenshot of mobile platforms after successful oc cluster up

### DIFF
--- a/modules/ROOT/pages/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/installing-mobile-services.adoc
@@ -156,6 +156,8 @@ password: password
 
 .. At the top of the catalog package, find the *Mobile* category that indicates that the mobile features of {org-name} {product-name} are succesfully installed.
 
+image:mobile-platforms.png[]
+
 == Next Steps
 
 * xref:registering-a-mobile-app.adoc[Register a Mobile App]


### PR DESCRIPTION
## JIRA

https://issues.jboss.org/browse/AEROGEAR-3523

## What

Add a screenshot of mobile platforms being available in the mobile tab after successful execution of 'oc cluster up' 

## Screenshot before:

![3523_before](https://user-images.githubusercontent.com/11087605/42166677-a47e2d76-7e03-11e8-8cd9-ce5396a314a6.jpg)

## Screenshot after:

![3523_after](https://user-images.githubusercontent.com/11087605/42166684-aa90d5ce-7e03-11e8-9ceb-1abb2822035a.jpg)

