### PR TITLE
AEROGEAR-3526 - IDM step review

### DIFF
--- a/modules/ROOT/pages/keycloak/keycloak-setup.adoc
+++ b/modules/ROOT/pages/keycloak/keycloak-setup.adoc
@@ -40,9 +40,5 @@ include::{partialsdir}/generic-service-nav.adoc[]
 . Open `Clients` from the menu.
 
 . Open your Android client.
-
-. Add the schema selected in the step 'Choose the schema of a redirect url' above to `Valid Redirect URIs`.
-
-. Add `*` to `Web Origins`.
-
-. Save your changes.
+. Add `<schema>:/callback` to `Valid Redirect URIs`.
+. Add `<schema>` to `Web Origins`.

--- a/modules/ROOT/pages/keycloak/keycloak-setup.adoc
+++ b/modules/ROOT/pages/keycloak/keycloak-setup.adoc
@@ -31,8 +31,6 @@ Depending on the platform set the redirect as described in either the Android or
 
 == Configuring {idm-name}
 
-include::{partialsdir}/generic-service-nav.adoc[]
-
 . Click on the Realm URL link to open the {idm-name} Administration Console.
 
 . Log in to the Administration console using the credentials you specified at xref:keycloak/provisioning.adoc[Provisioning] (defaults to admin:admin)


### PR DESCRIPTION
##JIRA
https://issues.jboss.org/browse/AEROGEAR-3526

## Additional Information
Removed an unnecessary step as the `create binding` is visible in the mobile service list, it is only after a service bind is the `>` icon visible.

In the Keycloak config, we tell the developer to add a wildcard to the web origins, this caused problems for us in the cordova showcase app. If we are to follow the config we have in `keycloak.security.feedhenry.org` setup, we have the schema (`org.aerogear.js.showcase`) added to the web origin and in the redirect uri's we have schema followed by `:/callback` added (`org.aerogear.js.showcase:/callback`).

Shall we follow the conventions we have in `keycloak.security.feedhenry.org`?