### PR TITLE
Fixed an error when publishing

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -6,7 +6,7 @@ site:
   start_page: aerogear::getting-started
 content:
   sources:
-  - url: git@github.com:aerogear/mobile-docs.git
+  - url: https://github.com/aerogear/mobile-docs.git
     branches: master
 ui:
   bundle:


### PR DESCRIPTION
Unsure if it's just me, but when running `./bin/publish.sh`, I get an error when cloning `mobile-docs`:

```
error: callback returned unsupported credentials type: git@github.com:aerogear/mobile-docs.git
```

Using an HTTP link instead works fine. May be a macOS issue? This should use work everything.