### PR TITLE
Another pass over getting started guide. 

### DIFF
--- a/modules/ROOT/pages/_partials/attributes.adoc
+++ b/modules/ROOT/pages/_partials/attributes.adoc
@@ -2,7 +2,7 @@
 
 :product-name: Mobile Services
 
-:release-number: 1.0.0-alpha
+:release-number: 1.0.0
 
 :service-name:
 

--- a/modules/ROOT/pages/_partials/generic-binding-procedure.adoc
+++ b/modules/ROOT/pages/_partials/generic-binding-procedure.adoc
@@ -1,4 +1,4 @@
-= Procedure
+== Procedure
 
 include::generic-service-nav.adoc[]
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -46,6 +46,7 @@ include::{partialsdir}/generic-provisioning-end.adoc[]
 
 [[binding]]
 include::keycloak/binding.adoc[leveloffset=1]
+
 [[localdev]]
 include::keycloak/keycloak-setup.adoc[leveloffset=2]
 
@@ -64,7 +65,7 @@ In order to perform local development, you will need to have set up a local deve
 
 == Running your First Mobile App
 
-=== Clone the showcase app:
+=== Clone the Showcase App
 
 include::{partialsdir}/cloning-showcase-app.adoc[]
 

--- a/modules/ROOT/pages/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/installing-mobile-services.adoc
@@ -42,7 +42,7 @@ Clone this repo to your local machine and check out the {release-number} tag usi
 +
 [source,bash,subs="attributes"]
 ----
-git clone git@github.com:aerogear/mobile-core.git
+git clone https://github.com/aerogear/mobile-core.git
 cd mobile-core
 git checkout {release-number}
 ----
@@ -65,7 +65,7 @@ are installed.
 ----
 DockerHub Tag (Defaults to latest):
 DockerHub Organisation (Defaults to aerogearcatalog):
-Cluster IP (Defaults to <Network IP Address>
+Cluster IP (Defaults to < Network IP Address >)
 Wildcard DNS Host (Defaults to nip.io):
 ----
 +


### PR DESCRIPTION
* Bumped release-number to 1.0.0 for recording videos. 
* Changed mobile-core clone URL from ssh to https. 
* Fixed indentation in generic binding
* Other minor updates