### PR TITLE
fixed docs url prefix

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -2,7 +2,7 @@ runtime:
   cache_dir: ./.cache/antora
 site:
   title: AeroGear Mobile Services
-  url: https://www.aerogear.org
+  url: https://docs.aerogear.org
   start_page: aerogear::getting-started
 content:
   sources:


### PR DESCRIPTION
## What

Fix the docs url prefix from 'www' to 'docs'

