### PR TITLE
Remove duplicate certs docs

### DIFF
--- a/modules/ROOT/pages/showcase-apps/service-setup.adoc
+++ b/modules/ROOT/pages/showcase-apps/service-setup.adoc
@@ -160,6 +160,3 @@ include::{partialsdir}/generic-obtaining-the-mobile-sdk-config-file.adoc[levelof
 
 
 include::{partialsdir}/build-and-deploy.adoc[]
-
-
-include::{partialsdir}/proc_self-signed-certs.adoc[leveloffset=1]


### PR DESCRIPTION
@finp The cert information was already included in a partial. This removes the additional one and ensures it's still referenced properly from the nav