### PR TITLE
remove not needed step

### DIFF
--- a/modules/ROOT/pages/showcase-apps/service-setup.adoc
+++ b/modules/ROOT/pages/showcase-apps/service-setup.adoc
@@ -111,8 +111,6 @@ include::{partialsdir}/cloning-showcase-app.adoc[]
 
 // TODO: fix link and numbering
 [start=2]
-. Configure the Mobile SDK as described in xref:configuring-dev-env.adoc#obtaining-the-mobile-sdk-configuration-file[Obtaining the Mobile SDK Configuration File]
-
 . If using xref:push/google-setup.adoc[Firebase Cloud Messaging] for push notifications, copy the `google-services.json` to your IDE.
 
 [role="primary"]


### PR DESCRIPTION
This step is not needed as it shows how to copy the `mobile-services.json`  in the following section.