### PR TITLE
update broken link

### DIFF
--- a/modules/ROOT/pages/push/binding.adoc
+++ b/modules/ROOT/pages/push/binding.adoc
@@ -19,7 +19,7 @@ include::{partialsdir}/attributes.adoc[]
 
 ****
 * [x] An Apple Developer account
-* [x] An APNs client TLS certificate. Have a look at link:apple-setup.html[APNs Setup] for further instructions.
+* [x] An APNs client TLS certificate. Have a look at link:../push-notifications.html#proc_preparing-ups-for-use-with-ios_preparing-ups-for-use-with-ios[APNs Setup] for further instructions.
 ****
 
 


### PR DESCRIPTION
**What**
Update the link to point to file with the details on getting APNS setup done for push

**Why**
Link was pointing to file that didn't exist

@aidenkeating @ciaranRoche The new link is to [here](https://docs.aerogear.org/aerogear/latest/push/proc_preparing-ups-for-use-with-ios.html) which I think has the correct content. can you confirm?