### PR TITLE
Bump required Ansible version to 2.6

### DIFF
--- a/modules/ROOT/pages/_partials/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/_partials/installing-mobile-services.adoc
@@ -14,7 +14,7 @@ NOTE: {org-name} recommends running OpenShift using the method described in this
 
 * A link:https://hub.docker.com/[Docker Hub] account
 
-* link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html[Ansible] (version 2.4 or above)
+* link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html[Ansible] (version 2.6 or above)
 
 * link:https://www.openshift.org/download.html[OpenShift client tools] version 3.9 or later
 +


### PR DESCRIPTION
Installer requires Ansible 2.6, see:
https://github.com/aerogear/mobile-core/blob/master/installer/install.sh#L118-L121