### PR TITLE
AEROGEAR-7541 - Add fedora firewall options

### DIFF
--- a/modules/ROOT/pages/_partials/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/_partials/installing-mobile-services.adoc
@@ -29,14 +29,6 @@ $ firewall-cmd --permanent --zone dockerc --add-port 443/tcp
 $ firewall-cmd --reload
 ----
 
-WARNING: Due to a number of services using ports which on Linux are restricted to root users only. This may result in issues if you try to interact with services on a local cluster from an external device. If you encounter these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are:
-
-----
-$ firewall-cmd --add-port 443/tcp
-$ firewall-cmd --add-port 80/tcp
-----
-
-
 [[procedure]]
 == Procedure
 
@@ -123,3 +115,13 @@ password: password
 .. At the top of the catalog package, find the *Mobile* category that indicates that the mobile features of {org-name} {product-name} are successfully installed.
 
 image:catalog-mobile-clients.png[]
+
+== Troubleshooting
+Firewall issues can occur with external devices trying to communicate with {product-name} provisioned on a Linux machine.
+This is due to a number of {product-name} are using ports which are restricted to root users only. If you encounter these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are:
+
+NOTE: The following command will only add the specified port for the current session. If you reload your firewall or restart your machine the specified port will be restricted again.
+----
+$ firewall-cmd --add-port 443/tcp
+$ firewall-cmd --add-port 80/tcp
+----

--- a/modules/ROOT/pages/_partials/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/_partials/installing-mobile-services.adoc
@@ -29,7 +29,7 @@ $ firewall-cmd --permanent --zone dockerc --add-port 443/tcp
 $ firewall-cmd --reload
 ----
 
-WARNING: Firewall issues may arise on Linux if you try to interact with services on a local cluster from an external device. In order to overcome these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are
+WARNING: Due to a number of services using ports which on Linux are restricted to root users only. This may result in issues if you try to interact with services on a local cluster from an external device. If you encounter these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are:
 
 ----
 $ firewall-cmd --add-port 443/tcp

--- a/modules/ROOT/pages/_partials/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/_partials/installing-mobile-services.adoc
@@ -29,6 +29,11 @@ $ firewall-cmd --permanent --zone dockerc --add-port 443/tcp
 $ firewall-cmd --reload
 ----
 
+WARNING: Firewall issues may arise on Linux if you try to interact with services on a local cluster from an external device. In order to overcome these issues, you can add the following ports to your firewall.
+----
+$ firewall-cmd --add-port 443/tcp
+$ firewall-cmd --add-port 80/tcp
+----
 
 
 [[procedure]]

--- a/modules/ROOT/pages/_partials/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/_partials/installing-mobile-services.adoc
@@ -118,7 +118,7 @@ image:catalog-mobile-clients.png[]
 
 == Troubleshooting
 Firewall issues can occur with external devices trying to communicate with {product-name} provisioned on a Linux machine.
-This is due to a number of {product-name} are using ports which are restricted to root users only. If you encounter these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are:
+This is due to a number of {product-name} using ports which are restricted to root users only. If you encounter these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are:
 
 NOTE: The following command will only add the specified port for the current session. If you reload your firewall or restart your machine the specified port will be restricted again.
 ----

--- a/modules/ROOT/pages/_partials/installing-mobile-services.adoc
+++ b/modules/ROOT/pages/_partials/installing-mobile-services.adoc
@@ -29,7 +29,8 @@ $ firewall-cmd --permanent --zone dockerc --add-port 443/tcp
 $ firewall-cmd --reload
 ----
 
-WARNING: Firewall issues may arise on Linux if you try to interact with services on a local cluster from an external device. In order to overcome these issues, you can add the following ports to your firewall.
+WARNING: Firewall issues may arise on Linux if you try to interact with services on a local cluster from an external device. In order to overcome these issues, you can add the ports to your firewall. Depending on the port your service uses, an example of the ports you may want to add to your firewall are
+
 ----
 $ firewall-cmd --add-port 443/tcp
 $ firewall-cmd --add-port 80/tcp


### PR DESCRIPTION
## JIRA
JIRA - https://issues.jboss.org/browse/AEROGEAR-7541

## Description

While investigating the above bug it was found that on Fedora all ports under 1025 are blocked, this meant that anyone running a local cluster on Fedora would not be able to interact with any services that used a port under 1025.

As it stands the documentation gets a Linux user to expose a port on their `dockerc` this on its own is not sufficient. 

This change adds a warning to the pre-req informing a Linux user of the potential issue and gives a solution. 

## Screenshot
![screen](https://user-images.githubusercontent.com/14313111/42688645-0a7ae2f6-8695-11e8-886e-82d480358380.png)

## Note
I have created an issue based on this PR to potentially add a troubleshooting section https://github.com/aerogear/mobile-docs/issues/280