### PR TITLE
Add step to Android Self Signed Certs

### DIFF
--- a/modules/ROOT/pages/_partials/proc_self-signed-certs.adoc
+++ b/modules/ROOT/pages/_partials/proc_self-signed-certs.adoc
@@ -51,6 +51,11 @@ Drive which is accessible from the device, browse to the certificate and
 proceed to download it.
 * USB - Attach the device to the machine hosting
 OpenShift via USB and drag the certificate to a devices file system. Here is an https://support.google.com/nexus/answer/2840804?hl=en[example guide for Google Nexus devices]. It may be different for other devices.
+* Android Debug Bridge (adb) - Use the adb push command to push the certificate to device or emulator:
++
+----
+$ adb push /tmp/localcluster.crt /sdcard/Download/localcluster.crt
+----
 .. Add the certificate to your device:
 +
 If you are using the email or cloud service approach, once the certificate file is downloaded, you will be prompted by the Android system automatically to install the file. You can simply follow the instructions to complete the process.

--- a/modules/ROOT/pages/_partials/proc_self-signed-certs.adoc
+++ b/modules/ROOT/pages/_partials/proc_self-signed-certs.adoc
@@ -51,7 +51,7 @@ Drive which is accessible from the device, browse to the certificate and
 proceed to download it.
 * USB - Attach the device to the machine hosting
 OpenShift via USB and drag the certificate to a devices file system. Here is an https://support.google.com/nexus/answer/2840804?hl=en[example guide for Google Nexus devices]. It may be different for other devices.
-* Android Debug Bridge (adb) - Use the adb push command to push the certificate to device or emulator:
+* link:https://developer.android.com/studio/command-line/adb[Android Debug Bridge] (adb) - Use the adb push command to push the certificate to device or emulator:
 +
 ----
 $ adb push /tmp/localcluster.crt /sdcard/Download/localcluster.crt


### PR DESCRIPTION
## Description
Currently, we do not have documented that we can push a certificate to a device using Android Debug Bridge. This method would be the quickest way for a developer to get a certificate onto a device.

## Screenshot
![command](https://user-images.githubusercontent.com/14313111/42753582-45ed2c08-88e9-11e8-8ad0-47457ba5b0ea.png)
