### PR TITLE
remove next steps and add terminology

### DIFF
--- a/modules/ROOT/pages/_partials/generic-service-intros.adoc
+++ b/modules/ROOT/pages/_partials/generic-service-intros.adoc
@@ -93,6 +93,11 @@ NOTE: {device-security-service} is not currently associated with an OpenShift se
 = {sync-service}
 //tag::sync-service[]
 
-TODO
+The {sync-service} service allows you to synchronize data between multiple mobile clients and easily query exactly the data you need.
+
+* Synchronize data between multiple clients
+* Define and connect your own data sources
+* Retrieve and update your records using GraphQL
+* Robust offline experience and good performance thanks to Apollo caching
 
 //end::sync-service[]

--- a/modules/ROOT/pages/data_sync.adoc
+++ b/modules/ROOT/pages/data_sync.adoc
@@ -5,7 +5,6 @@ include::sync/index.adoc[leveloffset=0]
 == Setting Up the Data Sync Mobile Service
 include::sync/provisioning.adoc[leveloffset=2]
 include::sync/binding.adoc[leveloffset=2]
-include::sync/coding.adoc[leveloffset=2]
 [#ui]
 include::sync/data_sources_ui.adoc[leveloffset=+1]
 [#sdk]

--- a/modules/ROOT/pages/sync/binding.adoc
+++ b/modules/ROOT/pages/sync/binding.adoc
@@ -5,7 +5,3 @@ include::{partialsdir}/attributes.adoc[]
 = Binding a {mobile-client} with the {service-name} Service
 
 include::{partialsdir}/generic-binding.adoc[]
-
-== Next Steps
-
-* xref:sync/adding-sync-to-your-app.adoc[Adding {sync-service} Service to your Application]

--- a/modules/ROOT/pages/sync/index.adoc
+++ b/modules/ROOT/pages/sync/index.adoc
@@ -19,7 +19,3 @@ include::./ref_terminology.adoc[leveloffset=+2]
 === Additional resources
 
 For more information, see the link:https://www.apollographql.com/docs/react/[Apollo Client Documentation]
-
-== Next Steps
-
-* xref:sync/provisioning.adoc[Provisioning {service-name} Service]

--- a/modules/ROOT/pages/sync/provisioning.adoc
+++ b/modules/ROOT/pages/sync/provisioning.adoc
@@ -31,7 +31,3 @@ oc describe dc postgres-data-sync -n <myproject> | grep POSTGRESQL_PASSWORD
 ====
 
 include::{partialsdir}/generic-provisioning-end.adoc[]
-
-== Next Steps
-
-* xref:sync/binding.adoc[Binding a {mobile-client} with the {service-name} Service]

--- a/modules/ROOT/pages/sync/ref_terminology.adoc
+++ b/modules/ROOT/pages/sync/ref_terminology.adoc
@@ -1,0 +1,14 @@
+include::{partialsdir}/attributes.adoc[]
+
+//':context:' is a vital parameter. See: http://asciidoctor.org/docs/user-manual/#include-multiple
+:context: ref_terminology_{sync-service}
+
+[id='{context}_ref_terminology']
+
+= {sync-service} Terminology
+
+This section describes terminology that is associated with {sync-service}.
+
+GraphQL:: A query language for data that is more powerfull than a REST API. See link:https://graphql.org/learn[GraphQL]
+
+Apollo:: A client side library to work with a GraphQL based server. See link:https://www.apollographql.com/[Apollo]


### PR DESCRIPTION
Removed the next steps. The sync docs now behave like one big document that you can srcoll from top to bottom and has anchors in nav.adoc.

I've also made a stab at the sync service intro and added some terminology.