### PR TITLE
update cordova location for mobile-services.json

### DIFF
--- a/modules/ROOT/pages/_partials/generic-obtaining-the-mobile-sdk-config-file.adoc
+++ b/modules/ROOT/pages/_partials/generic-obtaining-the-mobile-sdk-config-file.adoc
@@ -38,19 +38,9 @@ Locate this file at the following location in your application project:
 
 ****
 
-Locate this file in your application project and import it using `require`.
+Locate this file at the following location in your application project:
 
-[source,javascript]
-----
-const aerogearConfig = require("./mobile-services.json");
-----
-
-Alternatively you can create a JavaScript object and use directly:
-
-[source,javascript]
-----
-const aerogearConfig = /* Paste here the contents of the clipboard */;
-----
+`src/mobile-services.json`
 
 ****
 


### PR DESCRIPTION
Addresses #276  and reverses edits in https://github.com/aidenkeating/mobile-docs/commit/48e3ee85d1bb2adc42fc6409dd38fd9963b61656

Motivation:
We want to give the user simple clear instructions on what to do with mobile-services.json. 
While Cordova is flexible in how this is achieved, by giving them an opinionated path, we can make  Cordova easier to support.