### PR TITLE
Sync authorization docs

### DIFF
--- a/modules/ROOT/pages/sync/authorization.adoc
+++ b/modules/ROOT/pages/sync/authorization.adoc
@@ -1,0 +1,83 @@
+include::{partialsdir}/attributes.adoc[]
+
+:service-name: Data Sync
+
+= Role Based Authorization in {sync-service}
+
+== Prerequisites
+
+* xref:./binding_to_keycloak.adoc[Binding {sync-service} to Keycloak].
+* link:https://www.keycloak.org/docs/3.4/getting_started/index.html#creating-a-realm-and-user[Creating a Realm in Keycloak].
+* link:https://www.keycloak.org/docs/3.4/authorization_services/index.html#_getting_started_hello_world_enabling_authz_services[Enabling Authorization Services in Keycloak].
+* link:https://www.keycloak.org/docs/3.4/authorization_services/index.html#_policy_overview[Managing Policies in Keycloak]
+
+
+Role based authorization can be applied to Queries, Mutations, Subscriptions and individual fields in a GraphQL schema, when {sync-service} is used with Keycloak. This means it is possible to restrict individual fields and/or operations defined in the GraphQL schema to users with specific roles.
+
+Take a publishing platform as an example. Role Based Authorization could be used to ensure only users with the role `editor` can perform the `editPublication` mutation. 
+
+== Using the `hasRole` Directive to Apply Role Based Authorization on a Schema
+
+The following example demonstrates how the `hasRole` directive can be used to define role based authorization on various parts of a GraphQL schema. This example schema represents publishing application like a news or blog website.
+
+----
+type Post {
+  id: ID!
+  title: String!
+  author: Author!
+  content: String!
+  createdAt: Int!
+}
+
+type Author {
+  id: ID!
+  name: String!
+  posts: [Post]!
+  address: String! @hasRole(role: "admin")
+  age: Int! @hasRole(role: "admin")
+}
+
+type Query {
+  allPosts:[Post]!
+  getAuthor(id: ID!):Author!
+}
+
+type Mutation {
+  editPost:[Post]! @hasRole(role: ["editor", "admin"])
+  deletePost(id: ID!):[Post] @hasRole(role: "admin")
+}
+----
+
+There are two types:
+
+* `Post` - This might be an article or a blog post
+* `Author` - This would represent the person that authored a Post
+
+There are two Queries:
+
+* `allPosts` - This might return a list of posts
+* `getAuthor` - This would return details about an Author
+
+There are two Mutations:
+
+* `editPost` - This would edit an existing post
+* `deletePost` - This would delete a post.
+
+=== Role Based Authorization on Queries and Mutations
+
+In the example schema, the `hasRole` directive has been applied to the `editPost` and `deletePost` mutations. The same could be done on Queries.
+
+* Only users with the roles `editor` and/or `admin` are allowed to perform the `editPost` mutation.
+* Only users with the role `admin` are allowed to perform the `deletePost` mutation.
+
+This example shows how the `hasRole` directive can be used on various queries and mutations.
+
+=== Role Based Authorization on Fields
+
+In the example schema, the `Author` type has the fields `address` and `age` which both have `hasRole(role: "admin")` applied. 
+
+This means that users without the role `admin` are not authorized to request these fields **in any query or mutation**.
+
+For example, non admin users are allowed to run the `getAuthor` query, but they cannot request back the `address` or `age` fields.
+
+

--- a/modules/ROOT/pages/sync/authorization.adoc
+++ b/modules/ROOT/pages/sync/authorization.adoc
@@ -12,13 +12,40 @@ include::{partialsdir}/attributes.adoc[]
 * link:https://www.keycloak.org/docs/3.4/authorization_services/index.html#_policy_overview[Managing Policies in Keycloak]
 
 
-Role based authorization can be applied to Queries, Mutations, Subscriptions and individual fields in a GraphQL schema, when {sync-service} is used with Keycloak. This means it is possible to restrict individual fields and/or operations defined in the GraphQL schema to users with specific roles.
+Role based authorization can be applied to Queries, Mutations, Subscriptions and individual fields in a GraphQL schema, when {sync-service} is used with Keycloak. This means it is possible to restrict individual fields and/or operations defined in the GraphQL schema to users with specific roles in Keycloak.
 
-Take a publishing platform as an example. Role Based Authorization could be used to ensure only users with the role `editor` can perform the `editPublication` mutation. 
+Take a publishing platform as an example. Role Based Authorization could be used to ensure only users with the role `editor` can perform the `editPublication` mutation.
 
-== Using the `hasRole` Directive to Apply Role Based Authorization on a Schema
+{sync-service} currently supports authorization using **client** roles and **realm** roles defined in keycloak. Consult the Keycloak documentation to learn how to create roles.
 
-The following example demonstrates how the `hasRole` directive can be used to define role based authorization on various parts of a GraphQL schema. This example schema represents publishing application like a news or blog website.
+* link:https://www.keycloak.org/docs/4.3/server_admin/index.html#realm-roles[Realm Roles in Keycloak]
+* link:https://www.keycloak.org/docs/4.3/server_admin/index.html#client-roles[Client Roles in Keycloak]
+
+== The @hasRole Directive
+
+Role based authorization can be defined using the `@hasRole` directive. The `@hasRole` directive is a special annotation that can be applied to
+
+* Fields
+* Queries
+* Mutations
+* Subscriptions
+
+The `@hasRole` usage is as follows:
+
+* `@hasRole(role: String)`
+  * Example - `@hasRole(role: "admin])`
+  * If the authenticated user has the role `admin` they will be authorized.
+* `@hasRole(role: [String])`
+  * Example - `@hasRole(role: ["admin", "editor"])`
+  * If the authenticated user has **at least one of the roles** in the list, they will be authorized.
+
+**The default behaviour is to check client roles.** For example, `@hasRole(role: "admin")` will check that a user has a client role called `admin`.
+
+The syntax for checking a realm role is `@hasRole(role: "realm:<role>")`. For example, `@hasRole(role: "realm:admin")`. Using a list of roles, it is possible to check for both client and realm roles at the same time.
+
+== Example: Using the @hasRole Directive to Apply Role Based Authorization on a Schema
+
+The following example demonstrates how the `@hasRole` directive can be used to define role based authorization on various parts of a GraphQL schema. This example schema represents publishing application like a news or blog website.
 
 ----
 type Post {
@@ -65,12 +92,12 @@ There are two Mutations:
 
 === Role Based Authorization on Queries and Mutations
 
-In the example schema, the `hasRole` directive has been applied to the `editPost` and `deletePost` mutations. The same could be done on Queries.
+In the example schema, the `@hasRole` directive has been applied to the `editPost` and `deletePost` mutations. The same could be done on Queries.
 
 * Only users with the roles `editor` and/or `admin` are allowed to perform the `editPost` mutation.
 * Only users with the role `admin` are allowed to perform the `deletePost` mutation.
 
-This example shows how the `hasRole` directive can be used on various queries and mutations.
+This example shows how the `@hasRole` directive can be used on various queries and mutations.
 
 === Role Based Authorization on Fields
 

--- a/modules/ROOT/pages/sync/authorization.adoc
+++ b/modules/ROOT/pages/sync/authorization.adoc
@@ -33,13 +33,13 @@ Role based authorization can be defined using the `@hasRole` directive. The `@ha
 The `@hasRole` usage is as follows:
 
 * `@hasRole(role: String)`
-  * Example - `@hasRole(role: "admin])`
+  * Example - `@hasRole(role: "admin"])`
   * If the authenticated user has the role `admin` they will be authorized.
 * `@hasRole(role: [String])`
   * Example - `@hasRole(role: ["admin", "editor"])`
   * If the authenticated user has **at least one of the roles** in the list, they will be authorized.
 
-**The default behaviour is to check client roles.** For example, `@hasRole(role: "admin")` will check that a user has a client role called `admin`.
+**The default behaviour is to check client roles.** For example, `@hasRole(role: "admin"])` will check that user has a client role called `admin`. `@hasRole(role: "realm:admin"])` will check if that user has a realm role called `admin` 
 
 The syntax for checking a realm role is `@hasRole(role: "realm:<role>")`. For example, `@hasRole(role: "realm:admin")`. Using a list of roles, it is possible to check for both client and realm roles at the same time.
 


### PR DESCRIPTION
The purpose of this document:

* Directs the user to the appropriate keycloak documentation for configuring realms, client and realm roles.
* Explains `@hasRole` directive usage in detail.
* Gives a real world example of how the `@hasRole` directive might be used in a schema.