### PR TITLE
#444 Remove '+' typo

### DIFF
--- a/modules/ROOT/pages/metrics/coding.adoc
+++ b/modules/ROOT/pages/metrics/coding.adoc
@@ -15,7 +15,7 @@ Otherwise, install the core package by following the next steps depending on you
 ****
 
 Add the following dependency in your app's *build.gradle*:
-+
+
 [source,groovy,subs="attributes"]
 ----
 dependencies {


### PR DESCRIPTION
typo in Setting up Mobile Metrics service SDK (#444)