### PR TITLE
Update generic-binding.adoc

### DIFF
--- a/modules/ROOT/pages/_partials/generic-binding.adoc
+++ b/modules/ROOT/pages/_partials/generic-binding.adoc
@@ -2,7 +2,7 @@
 To use mobile services, you must represent your mobile app in OpenShift using a {mobile-client}, and that {mobile-client} must be associated with the mobile service.
 This association is called *binding* and it is necessary for your mobile app to use that service.
 
-To associate a {mobile-client} with a mobile service:
+To bind a {mobile-client} with a mobile service:
 
 include::{partialsdir}/generic-binding-procedure.adoc[]
 


### PR DESCRIPTION
### Why?
Associate" is never used in docs.