### PR TITLE
removed sitemap hack

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -15,10 +15,3 @@ antora --clean --pull site.yml
 
 ./bin/fix-div.sh
 
-# replace the generated sitemap.xml by a static one (with updated timestamps)
-
-cp bin/sitemap.xml ./build/site/sitemap.xml
-
-# replace the timestamp from the template by one representing current time and date
-
-sed -i "s/\(<lastmod.*>\)[^<>]*\(<\/lastmod.*\)/\1$(date +"%Y-%m-%dT%H:%M:%S.000Z")\2/" ./build/site/sitemap.xml


### PR DESCRIPTION
## Motivation
remove build script section relating to sitemap
## What
use native sitemap
## Why
we had an issue where we were publishing lots of files, but only wanted google to 'see' a subset, so we hacked the sitemap.xml file as part of build .
No longer necessary, removed logic