### PR TITLE
AGMS-43 import and use new tab system

### DIFF
--- a/lib/tab-block.js
+++ b/lib/tab-block.js
@@ -1,0 +1,76 @@
+/**
+ * Extends the AsciiDoc syntax to support a tabset element. The tabset is
+ * created from a dlist that is enclosed in an example block marked with the
+ * tabs style.
+ *
+ * Usage:
+ *
+ *  [tabs]
+ *  ====
+ *  Tab A::
+ *  +
+ *  --
+ *  Contents of tab A.
+ *  --
+ *  Tab B::
+ *  +
+ *  --
+ *  Contents of tab B.
+ *  --
+ *  ====
+ *
+ * To use this extension, register the extension.js file with Antora (i.e.,
+ * list it as an AsciiDoc extension in the Antora playbook file), combine
+ * styles.css with the styles for the site, and combine behavior.js with the
+ * JavaScript loaded by the page.
+ *
+ * @author Dan Allen <dan@opendevise.com>
+ */
+const IdSeparatorChar = '-'
+const InvalidIdCharsRx = /[^a-zA-Z0-9_]/g
+const List = Opal.const_get_local(Opal.module(null, 'Asciidoctor'), 'List')
+const ListItem = Opal.const_get_local(Opal.module(null, 'Asciidoctor'), 'ListItem')
+
+const generateId = (str, idx) => `tabset${idx}_${str.toLowerCase().replace(InvalidIdCharsRx, IdSeparatorChar)}`
+
+function tabsBlock () {
+  this.onContext('example')
+  this.process((parent, reader, attrs) => {
+    const createHtmlFragment = (html) => this.createBlock(parent, 'pass', html)
+    const tabsetIdx = parent.getDocument().counter('idx-tabset')
+    const nodes = []
+    nodes.push(createHtmlFragment('<div class="tabset is-loading">'))
+    const container = this.parseContent(this.createBlock(parent, 'open'), reader)
+    const sourceTabs = container.getBlocks()[0]
+    if (!(sourceTabs && sourceTabs.getContext() === 'dlist' && sourceTabs.getItems().length)) return
+    const tabs = List.$new(parent, 'ulist')
+    tabs.addRole('tabs')
+    const panes = {}
+    sourceTabs.getItems().forEach(([[title], details]) => {
+      const tab = ListItem.$new(tabs)
+      tabs.$append(tab)
+      const id = generateId(title.getText(), tabsetIdx)
+      tab.text = `[[${id}]]${title.text}`
+      let blocks = details.getBlocks()
+      const numBlocks = blocks.length
+      if (numBlocks) {
+        if (blocks[0].context === 'open' && numBlocks === 1) blocks = blocks[0].getBlocks()
+        panes[id] = blocks.map((block) => (block.parent = parent) && block)
+      }
+    })
+    nodes.push(tabs)
+    nodes.push(createHtmlFragment('<div class="content">'))
+    Object.entries(panes).forEach(([id, blocks]) => {
+      nodes.push(createHtmlFragment(`<div class="tab-pane" aria-labelledby="${id}">`))
+      nodes.push(...blocks)
+      nodes.push(createHtmlFragment('</div>'))
+    })
+    nodes.push(createHtmlFragment('</div>'))
+    nodes.push(createHtmlFragment('</div>'))
+    parent.blocks.push(...nodes)
+  })
+}
+
+module.exports.register = (registry, context) => {
+  registry.block('tabs', tabsBlock)
+}

--- a/local-site.yml
+++ b/local-site.yml
@@ -15,6 +15,7 @@ ui:
 
 asciidoc:
   extensions:
+  - ./lib/tab-block.js
   - ./lib/remote-include-processor
   attributes:
     experimental: ''

--- a/modules/ROOT/pages/_partials/keycloak/keycloak-setup.adoc
+++ b/modules/ROOT/pages/_partials/keycloak/keycloak-setup.adoc
@@ -11,26 +11,36 @@ For an explanation of these terms, see link:https://www.keycloak.org/documentati
 [[choose-schema]]
 == Choose the schema of a redirect url
 
-[role="primary"]
-.Android
-****
+
+
+
+[tabs]
+====
+Android::
++
+--
 It is recommended to use the package name of the Android app as the schema of the redirect url to avoid conflicts. (e.g. `com.aerogear.androidshowcase`)
-****
-[role="secondary"]
-.iOS
-****
+--
+iOS::
++
+--
 It is recommended to use the Bundle Identifier of the iOS app as the schema of the redirect url. (e.g. `org.aerogear.ios-showcase-template`)
-****
-[role="secondary"]
-.Cordova
-****
+--
+Cordova::
++
+--
 Redirect url is `\http://localhost/\*`, without `:/callback`. Web Origin is `\http://localhost/*`.
-****
-[role="secondary"]
-.Xamarin
-****
+--
+Xamarin::
++
+--
 Depending on the platform, set the redirect as described in either the Android or the iOS tab.
-****
+--
+====
+
+
+
+
 
 == Configuring {idm-name}
 

--- a/site.yml
+++ b/site.yml
@@ -16,6 +16,8 @@ ui:
     snapshot: true
 
 asciidoc:
+  extensions:
+  - ./lib/tab-block.js
   attributes:
     experimental: ''
     idprefix: ''

--- a/testui-site.yml
+++ b/testui-site.yml
@@ -17,7 +17,6 @@ asciidoc:
   extensions:
   - ./lib/remote-include-processor
   - ./lib/tab-block.js
-  - ./lib/tab-block
   attributes:
     experimental: ''
     idprefix: ''

--- a/testui-site.yml
+++ b/testui-site.yml
@@ -16,6 +16,8 @@ ui:
 asciidoc:
   extensions:
   - ./lib/remote-include-processor
+  - ./lib/tab-block.js
+  - ./lib/tab-block
   attributes:
     experimental: ''
     idprefix: ''


### PR DESCRIPTION
AGMS-43
Allows:
* building with native antora
* better syntax
* supported codebase at https://gitlab.com/antora/antora-asciidoctor-extensions/blob/master/tabs-block/extension.js

