### PR TITLE
remove mobile-security from build

### DIFF
--- a/site-mobile-security.yml
+++ b/site-mobile-security.yml
@@ -8,6 +8,8 @@ content:
   sources:
   - url: https://github.com/aerogear/mobile-docs.git
     branches: [master, v1.0]
+  - url: https://github.com/aerogear/mobile-security.git
+    branches: master
 ui:
   bundle:
     url: https://github.com/aerogear/antora-ui/raw/master/build/ui-bundle.zip


### PR DESCRIPTION


eg
```
mobileNetworkOverview.adoc: line 172: include target not found: https://raw.githubusercontent.com/feedhenry/mobile-security-cordova-template/0c8ccb1e1b01336aba47b596102e89575740d6ce/src/config/keycloak.json

```
This was not an issue with V1.x or V2 RCs. It's probably a reduction in asciidoctor priv in the antora pipeline

## What
Remove from site.yml
Create a file to test mobile security later

This will not affect the existing published work, it just means it's not updated, and there hasn't been an update since oct 18:

https://github.com/aerogear/mobile-security