### PR TITLE
fix: remove mentions of defunct noSquash ability

### DIFF
--- a/modules/ROOT/pages/_partials/sync/js-client-offline-and-conflict.adoc
+++ b/modules/ROOT/pages/_partials/sync/js-client-offline-and-conflict.adoc
@@ -59,34 +59,6 @@ exampleQuery(...) @onlineOnly {
 }
 ----
 
-=== Squashing Mutations
-
-By default, multiple changes performed on the same object ID and with the same mutation will be automatically merged when the client is offline. The advantages of this approach are it can reduce the number of mutations that need to be stored, and reduce the number of replays when the client is online again. If this behavior is not desired, it can be turned off at different levels.
-
-==== Global Squashing
-
-This feature is on by default at a global level, it can be turned off in the config using the `mergeOfflineMutations` option.
-
-[source,javascript]
-----
-let config = {
-...
-  mergeOfflineMutations: false
-...
-}
-----
-
-==== Mutation Level Squashing
-
-To disable this feature at a mutation level, the `@noSqush` directive can be used to annotate mutations:
-
-[source, graphql]
-----
-exampleMutation(...) @noSquash {
-  ...
-}
-----
-
 [#sync-client-offline-queue-listener]
 == Listening for Events
 

--- a/modules/ROOT/pages/_partials/sync/server-offline-and-conflict.adoc
+++ b/modules/ROOT/pages/_partials/sync/server-offline-and-conflict.adoc
@@ -28,6 +28,7 @@ Pluggable conflict resolution is a concept that allows developers to define thei
 The conflict detection and resolution is enabled by {sync-server}, while the fetching and storing of data is the responsibility of the developer.
 
 Pluggable conflict resolution supports the following implementations:
+
 * `VersionedObjectState` - depends on version field supplied in objects (used by default when importing conflictHandler)
 * `HashObjectState` - depends on hash calculated from entire object
 


### PR DESCRIPTION
## Motivation
Remove any references to the no longer used @noSquash directive or global squashing.