### PR TITLE
AEROGEAR-9671

### DIFF
--- a/modules/ROOT/pages/_partials/data-sync/js-client-query.adoc
+++ b/modules/ROOT/pages/_partials/data-sync/js-client-query.adoc
@@ -66,6 +66,7 @@ $ node index-2.js
 [source,bash]
 ----
 npm install @aerogear/voyager-client
+npm install graphql
 npm install graphql-tag
 ----
 +


### PR DESCRIPTION
## Motivation
Following test for Data Sync documentation
https://issues.jboss.org/browse/AGMS-609


## What
Add
```
npm install graphql
```
to 
https://mobile-docs.netlify.com/aerogear/latest/ds-query/

## Why
Assuming that a user is using webpack getting started guide to generate client, client would not be in the same folder as server so graphQL needs to be installed on client side as well.


## Verification Steps
1. Open https://mobile-docs.netlify.com/aerogear/latest/data-sync/
2. Go through Getting Started
3. In Queries section go through webpack
4. Without installing graphql you should get an error with graphql tag
 

 

