### PR TITLE
URL fix For Downstream Showcase AppContent

### DIFF
--- a/modules/ROOT/pages/_partials/showcase-apps/push-notifications.adoc
+++ b/modules/ROOT/pages/_partials/showcase-apps/push-notifications.adoc
@@ -4,5 +4,5 @@
 
 
 . Send a push notification as described in
-link{push-notification}#sending[Sending a Push Notification]
+link:{push-guide-link}#sending[Sending a Push Notification]
 . Launch the showcase app and view the notification.


### PR DESCRIPTION
Fix for content snippet: "link{push-notification}#sending[Sending a Push Notification]" is downstream showcase app.