### PR TITLE
AEROGEAR-9888-explain versions

### DIFF
--- a/modules/ROOT/pages/_partials/app-security/using-the-admin-ui.adoc
+++ b/modules/ROOT/pages/_partials/app-security/using-the-admin-ui.adoc
@@ -11,9 +11,14 @@ The console is only available after the {app-security-service} Service has been 
 
 .Overview of the Mobile Security Console
 
-The {app-security-service} Console allows you to monitor applications, their respective versions, and disable versions of those applications.
+The {app-security-service} Console allows you to monitor mobile apps, deployed versions, and disable versions of those mobile apps.
 
-Opening the console lists all applications. Click on an application to view version details for that application.
+Opening the console lists all applications. Click on an application to view deployed versions of that mobile app.
+
+A deployed version is registered with Mobile Security after:
+
+* A version of the app is released, for example, 1.2.3.
+* The version of the app is run on a device at least once.
 
 Below is a detailed description of each of these views and the information you can expect each to contain.
 


### PR DESCRIPTION
## Purpose

add more context around versions, to avoid scenarios like:

I just released a new version of my app, and know there's an issue, but I can't disable it, because it's not appearing in MSS console

