### PR TITLE
fix rendering

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -3,7 +3,7 @@ runtime:
 site:
   title: AeroGear Mobile Services
   url: https://docs.aerogear.org
-  start_page: aerogear::getting-started
+  start_page: latest@aerogear::getting-started
 content:
   sources:
   - url: https://github.com/aerogear/mobile-docs.git


### PR DESCRIPTION
## Purpose
after adding native branch to render, it became the default.
Antora defaults to showing latest version  and 'native' beat master, V2.0 

Fix is to explicitly add the default branch as per https://docs.antora.org/antora/2.1/playbook/configure-site/


